### PR TITLE
Create Docker-multi-stage

### DIFF
--- a/Docker-multi-stage
+++ b/Docker-multi-stage
@@ -1,0 +1,28 @@
+# ---------- Stage 1: Build ----------
+FROM openjdk:17-jdk-alpine AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy source files into container
+COPY src/Main.java /app/
+COPY quotes.txt /app/
+
+# Compile Java source
+RUN javac Main.java
+
+# ---------- Stage 2: Runtime ----------
+FROM openjdk:17-jdk-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy only the compiled class and required files from builder stage
+COPY --from=builder /app/Main.class /app/
+COPY --from=builder /app/quotes.txt /app/
+
+# Expose the application port
+EXPOSE 8000
+
+# Run the app
+CMD ["java", "Main"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default container now exposes port 8000 for easier access.
- Refactor
  - Separated build and runtime into distinct container stages for cleaner deployments.
- Chores
  - Adopted a multi-stage container build on Java 17, reducing image size and improving pull/startup times.
  - Standardized runtime environment for consistency across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->